### PR TITLE
Use __cplusplus guard

### DIFF
--- a/popen_noshell.c
+++ b/popen_noshell.c
@@ -166,6 +166,8 @@ void _popen_noshell_child_process_cleanup_fail_and_exit(int exit_code, struct po
 		/* free this copied memory; if it was not Valgrind, this memory would have been shared and would belong to the parent! */
 		_pclose_noshell_free_clone_arg_memory(arg_ptr);
 	}
+#else
+	(void) arg_ptr;
 #endif
 
 	if (fflush(stdout) != 0) _ERR(255, "fflush(stdout)");

--- a/popen_noshell.h
+++ b/popen_noshell.h
@@ -23,6 +23,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* stack for the child process before it does exec() */
 #define POPEN_NOSHELL_STACK_SIZE 8*1024*1024 /* currently most Linux distros set this to 8 MBytes */
 
@@ -67,5 +71,9 @@ pid_t popen_noshell_vmfork(int (*fn)(void *), void *arg, void **memory_to_free_o
 /* used only for benchmarking purposes */
 void popen_noshell_set_fork_mode(int mode);
 int popen_noshell_get_fork_mode();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Hi!

With automated build systems, the popen_noshell.c is built with C bindings, but the header file might be read by a C++ compiler (and thus create C++ mangled symbol names.)

This small patch forces a C++ compiler to use the proper C symbols. That will enable to link the C code with a C++ compiler/linker, and will still work then the C code is actually compiled with a C++ compiler.

Thanks,
  Jan-Benedict